### PR TITLE
Revision of the premint logic

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -3384,6 +3384,752 @@
         },
         "namespaces": {}
       }
+    },
+    "c0a159d7500d0224bec56f8272370e1fb41ac6474e10124bd72446adaf8483e9": {
+      "address": "0x6D26cc9Ca07649FB9F4Fc2056C88ED5Eb42f3109",
+      "txHash": "0x381291d9efe36828bd51c04e48980b1e22e3a1948748c66dccb651c81c8f7da9",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)23_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:150"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\PausableExtUpgradeable.sol:73"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\RescuableUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "contracts\\base\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:13"
+          },
+          {
+            "label": "_cashOutBalances",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:16"
+          },
+          {
+            "label": "_cashOuts",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:19"
+          },
+          {
+            "label": "_pendingCashOutTxIds",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_struct(Bytes32Set)3677_storage",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:22"
+          },
+          {
+            "label": "_processedCashOutCounter",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_uint256",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:25"
+          },
+          {
+            "label": "_cashIns",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)",
+            "contract": "PixCashierStorageV2",
+            "src": "contracts\\PixCashierStorage.sol:33"
+          },
+          {
+            "label": "_cashInBatches",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)",
+            "contract": "PixCashierStorageV3",
+            "src": "contracts\\PixCashierStorage.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashInBatchStatus)6362": {
+            "label": "enum IPixCashierTypes.CashInBatchStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashInStatus)6358": {
+            "label": "enum IPixCashierTypes.CashInStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashOutStatus)6374": {
+            "label": "enum IPixCashierTypes.CashOutStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInBatchOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashOut)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)23_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Bytes32Set)3677_storage": {
+            "label": "struct EnumerableSetUpgradeable.Bytes32Set",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3483_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashInBatchOperation)6386_storage": {
+            "label": "struct IPixCashierTypes.CashInBatchOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInBatchStatus)6362",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CashInOperation)6382_storage": {
+            "label": "struct IPixCashierTypes.CashInOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInStatus)6358",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashOut)6394_storage": {
+            "label": "struct IPixCashierTypes.CashOut",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashOutStatus)6374",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)23_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)3483_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "f281650c4a9bde80da308d59af838bc4a55e6e8ccc4dbfe4f8dd3fbf7a7f43da": {
+      "address": "0xfA135A6A35EF29E011AF659f8Ec1434061f672F9",
+      "txHash": "0xc7c0e578f45268991274d133766e1df60262e764973913b8e877bc08ff33e77a",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)23_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:150"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\PausableExtUpgradeable.sol:73"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\RescuableUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "contracts\\base\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:13"
+          },
+          {
+            "label": "_cashOutBalances",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:16"
+          },
+          {
+            "label": "_cashOuts",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:19"
+          },
+          {
+            "label": "_pendingCashOutTxIds",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_struct(Bytes32Set)3677_storage",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:22"
+          },
+          {
+            "label": "_processedCashOutCounter",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_uint256",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:25"
+          },
+          {
+            "label": "_cashIns",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)",
+            "contract": "PixCashierStorageV2",
+            "src": "contracts\\PixCashierStorage.sol:33"
+          },
+          {
+            "label": "_cashInBatches",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)",
+            "contract": "PixCashierStorageV3",
+            "src": "contracts\\PixCashierStorage.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashInBatchStatus)6362": {
+            "label": "enum IPixCashierTypes.CashInBatchStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashInStatus)6358": {
+            "label": "enum IPixCashierTypes.CashInStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashOutStatus)6374": {
+            "label": "enum IPixCashierTypes.CashOutStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInBatchOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashOut)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)23_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Bytes32Set)3677_storage": {
+            "label": "struct EnumerableSetUpgradeable.Bytes32Set",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3483_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashInBatchOperation)6386_storage": {
+            "label": "struct IPixCashierTypes.CashInBatchOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInBatchStatus)6362",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CashInOperation)6382_storage": {
+            "label": "struct IPixCashierTypes.CashInOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInStatus)6358",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashOut)6394_storage": {
+            "label": "struct IPixCashierTypes.CashOut",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashOutStatus)6374",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)23_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)3483_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -3015,6 +3015,752 @@
         },
         "namespaces": {}
       }
+    },
+    "c0a159d7500d0224bec56f8272370e1fb41ac6474e10124bd72446adaf8483e9": {
+      "address": "0xEFEf9c26a7550548ee24F54e0734B326264cdcCc",
+      "txHash": "0xcdbc49d352c261c14064a04fbea53c4888e717a3f9df3b44440a4f686a478ee3",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)23_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:150"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\PausableExtUpgradeable.sol:73"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\RescuableUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "contracts\\base\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:13"
+          },
+          {
+            "label": "_cashOutBalances",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:16"
+          },
+          {
+            "label": "_cashOuts",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:19"
+          },
+          {
+            "label": "_pendingCashOutTxIds",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_struct(Bytes32Set)3677_storage",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:22"
+          },
+          {
+            "label": "_processedCashOutCounter",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_uint256",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:25"
+          },
+          {
+            "label": "_cashIns",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)",
+            "contract": "PixCashierStorageV2",
+            "src": "contracts\\PixCashierStorage.sol:33"
+          },
+          {
+            "label": "_cashInBatches",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)",
+            "contract": "PixCashierStorageV3",
+            "src": "contracts\\PixCashierStorage.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashInBatchStatus)6362": {
+            "label": "enum IPixCashierTypes.CashInBatchStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashInStatus)6358": {
+            "label": "enum IPixCashierTypes.CashInStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashOutStatus)6374": {
+            "label": "enum IPixCashierTypes.CashOutStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInBatchOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashOut)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)23_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Bytes32Set)3677_storage": {
+            "label": "struct EnumerableSetUpgradeable.Bytes32Set",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3483_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashInBatchOperation)6386_storage": {
+            "label": "struct IPixCashierTypes.CashInBatchOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInBatchStatus)6362",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CashInOperation)6382_storage": {
+            "label": "struct IPixCashierTypes.CashInOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInStatus)6358",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashOut)6394_storage": {
+            "label": "struct IPixCashierTypes.CashOut",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashOutStatus)6374",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)23_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)3483_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "f281650c4a9bde80da308d59af838bc4a55e6e8ccc4dbfe4f8dd3fbf7a7f43da": {
+      "address": "0xbBF69Df9DeDec90A9e4D5092825032bBC2120627",
+      "txHash": "0xd89bf06e49ae519c842fbbb498eb01f68cba7085a819093ea1ce1227cbc3a25b",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:63",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:68"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\introspection\\ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)23_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:57"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:260"
+          },
+          {
+            "label": "_blocklisted",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "BlocklistableUpgradeable",
+            "src": "contracts\\base\\BlocklistableUpgradeable.sol:150"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\security\\PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "PausableExtUpgradeable",
+            "src": "contracts\\base\\PausableExtUpgradeable.sol:73"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RescuableUpgradeable",
+            "src": "contracts\\base\\RescuableUpgradeable.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)200_storage",
+            "contract": "StoragePlaceholder200",
+            "src": "contracts\\base\\StoragePlaceholder200.sol:39"
+          },
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "551",
+            "type": "t_address",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:13"
+          },
+          {
+            "label": "_cashOutBalances",
+            "offset": 0,
+            "slot": "552",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:16"
+          },
+          {
+            "label": "_cashOuts",
+            "offset": 0,
+            "slot": "553",
+            "type": "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:19"
+          },
+          {
+            "label": "_pendingCashOutTxIds",
+            "offset": 0,
+            "slot": "554",
+            "type": "t_struct(Bytes32Set)3677_storage",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:22"
+          },
+          {
+            "label": "_processedCashOutCounter",
+            "offset": 0,
+            "slot": "556",
+            "type": "t_uint256",
+            "contract": "PixCashierStorageV1",
+            "src": "contracts\\PixCashierStorage.sol:25"
+          },
+          {
+            "label": "_cashIns",
+            "offset": 0,
+            "slot": "557",
+            "type": "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)",
+            "contract": "PixCashierStorageV2",
+            "src": "contracts\\PixCashierStorage.sol:33"
+          },
+          {
+            "label": "_cashInBatches",
+            "offset": 0,
+            "slot": "558",
+            "type": "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)",
+            "contract": "PixCashierStorageV3",
+            "src": "contracts\\PixCashierStorage.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)200_storage": {
+            "label": "uint256[200]",
+            "numberOfBytes": "6400"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(CashInBatchStatus)6362": {
+            "label": "enum IPixCashierTypes.CashInBatchStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashInStatus)6358": {
+            "label": "enum IPixCashierTypes.CashInStatus",
+            "members": [
+              "Nonexistent",
+              "Executed",
+              "PremintExecuted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(CashOutStatus)6374": {
+            "label": "enum IPixCashierTypes.CashOutStatus",
+            "members": [
+              "Nonexistent",
+              "Pending",
+              "Reversed",
+              "Confirmed"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInBatchOperation)6386_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInBatchOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashInOperation)6382_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashInOperation)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(CashOut)6394_storage)": {
+            "label": "mapping(bytes32 => struct IPixCashierTypes.CashOut)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)23_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Bytes32Set)3677_storage": {
+            "label": "struct EnumerableSetUpgradeable.Bytes32Set",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3483_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashInBatchOperation)6386_storage": {
+            "label": "struct IPixCashierTypes.CashInBatchOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInBatchStatus)6362",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CashInOperation)6382_storage": {
+            "label": "struct IPixCashierTypes.CashInOperation",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(CashInStatus)6358",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(CashOut)6394_storage": {
+            "label": "struct IPixCashierTypes.CashOut",
+            "members": [
+              {
+                "label": "account",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(CashOutStatus)6374",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)23_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)3483_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -650,7 +650,7 @@ contract PixCashier is
         ) {
             revert InvalidBatchArrays();
         }
-        if (_cashInBatches[batchId].status == CashInBatchStatus.Executed) {
+        if (_cashInBatches[batchId].status != CashInBatchStatus.Nonexistent) {
             revert CashInBatchAlreadyExecuted(batchId);
         }
         if (batchId == 0) {
@@ -698,7 +698,7 @@ contract PixCashier is
         if (batchId == 0) {
             revert ZeroBatchId();
         }
-        if (_cashInBatches[batchId].status == CashInBatchStatus.Executed) {
+        if (_cashInBatches[batchId].status != CashInBatchStatus.Nonexistent) {
             revert CashInBatchAlreadyExecuted(batchId);
         }
 

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -270,6 +270,7 @@ contract PixCashier is
             account,
             amount,
             txId,
+            0, // releaseTime
             CashInExecutionPolicy.Revert
         );
     }
@@ -290,11 +291,15 @@ contract PixCashier is
         bytes32 txId,
         uint256 releaseTime
     ) external whenNotPaused onlyRole(CASHIER_ROLE) {
-        _cashInPremintCreate(
+        if (releaseTime == 0) {
+            revert InappropriatePremintReleaseTime();
+        }
+        _cashIn(
             account,
             amount,
             txId,
-            releaseTime
+            releaseTime,
+            CashInExecutionPolicy.Revert
         );
     }
 
@@ -311,34 +316,10 @@ contract PixCashier is
         bytes32 txId,
         uint256 releaseTime
     ) external whenNotPaused onlyRole(CASHIER_ROLE) {
-        _cashInPremintUpdate(
-            0,
+        _cashInPremintRevoke(
             txId,
-            releaseTime
-        );
-    }
-
-    /**
-     * @dev See {IPixCashier-cashInPremint}.
-     *
-     * Requirements:
-     *
-     * - The contract must not be paused.
-     * - The caller must have the {CASHIER_ROLE} role.
-     * - The provided `account`, `amount`, `txId` and `releaseTime` values must not be zero.
-     */
-    function cashInPremintUpdate(
-        uint256 amount,
-        bytes32 txId,
-        uint256 releaseTime
-    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
-        if (amount == 0) {
-            revert ZeroAmount();
-        }
-        _cashInPremintUpdate(
-            amount,
-            txId,
-            releaseTime
+            releaseTime,
+            CashInExecutionPolicy.Revert
         );
     }
 
@@ -347,14 +328,12 @@ contract PixCashier is
      *
      * Requirements
      *
-     * - The length of each passed array must be equal.
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
      * - The provided `account`, `amount`, and `txId` values must not be zero.
      * - The provided `accounts`, `amounts`, `txIds` arrays must not be empty and must have the same length.
-     * - The provided `batchId` must not be zero
+     * - The provided `batchId` must not be zero.
      * - The cash-in batch operation with the provided `batchId` must not be already executed.
-     * - Each cash-in operation with the provided identifier from the `txIds` array must not be already executed.
      */
     function cashInBatch(
         address[] memory accounts,
@@ -362,34 +341,68 @@ contract PixCashier is
         bytes32[] memory txIds,
         bytes32 batchId
     ) external whenNotPaused onlyRole(CASHIER_ROLE) {
-        if (
-            accounts.length == 0 ||
-            accounts.length != amounts.length ||
-            accounts.length != txIds.length
-        ) {
-            revert InvalidBatchArrays();
-        }
-        if (_cashInBatches[batchId].status == CashInBatchStatus.Executed) {
-            revert CashInBatchAlreadyExecuted(batchId);
-        }
-        if (batchId == 0) {
-            revert ZeroBatchId();
-        }
+        _cashInBatch(
+            accounts,
+            amounts,
+            txIds,
+            0, // releaseTime
+            batchId
+        );
+    }
 
-        CashInExecutionResult[] memory executionResults = new CashInExecutionResult[](txIds.length);
-
-        for (uint256 i = 0; i < accounts.length; i++) {
-            executionResults[i] = _cashIn(
-                accounts[i],
-                amounts[i],
-                txIds[i],
-                CashInExecutionPolicy.Skip
-            );
+    /**
+     * @dev See {IPixCashier-cashInPremintBatch}.
+     *
+     * Requirements
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {CASHIER_ROLE} role.
+     * - The provided `account`, `amount`, and `txId` values must not be zero.
+     * - The provided `accounts`, `amounts`, `txIds` arrays must not be empty and must have the same length.
+     * - The provided `batchId` and `releaseTime` must not be zero.
+     * - The cash-in batch operation with the provided `batchId` must not be already executed.
+     */
+    function cashInPremintBatch(
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bytes32[] memory txIds,
+        uint256 releaseTime,
+        bytes32 batchId
+    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
+        if (releaseTime == 0) {
+            revert InappropriatePremintReleaseTime();
         }
+        _cashInBatch(
+            accounts,
+            amounts,
+            txIds,
+            releaseTime,
+            batchId
+        );
+    }
 
-        _cashInBatches[batchId].status = CashInBatchStatus.Executed;
-
-        emit CashInBatch(batchId, txIds, executionResults);
+    /**
+     * @dev See {IPixCashier-cashInPremintRevokeBatch}.
+     *
+     * Requirements
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {CASHIER_ROLE} role.
+     * - The provided `txId` values must not be zero.
+     * - The provided `txIds` array must not be empty.
+     * - The provided `batchId` and `releaseTime` must not be zero.
+     * - The cash-in batch operation with the provided `batchId` must not be already executed.
+     */
+    function cashInPremintRevokeBatch(
+        bytes32[] memory txIds,
+        uint256 releaseTime,
+        bytes32 batchId
+    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
+        _cashInPremintRevokeBatch(
+            txIds,
+            releaseTime,
+            batchId
+        );
     }
 
     /**
@@ -509,11 +522,12 @@ contract PixCashier is
     }
 
     /**
-     * @dev Executes a cash-in operation internally depending on the execution policy.
+     * @dev Executes a cash-in operation internally depending on the execution policy and release time.
      *
      * @param account The address of the tokens recipient.
      * @param amount The amount of tokens to be received.
      * @param txId The off-chain transaction identifier of the operation.
+     * @param releaseTime Zero if the cash-in is common otherwise the release time of the preminted tokens.
      * @param policy The execution policy of the operation.
      * @return The result of the operation according to the appropriate enum.
      */
@@ -521,6 +535,7 @@ contract PixCashier is
         address account,
         uint256 amount,
         bytes32 txId,
+        uint256 releaseTime,
         CashInExecutionPolicy policy
     ) internal returns (CashInExecutionResult) {
         if (account == address(0)) {
@@ -544,75 +559,39 @@ contract PixCashier is
             }
         }
 
-        _cashIns[txId] = CashInOperation({
-            status: CashInStatus.Executed,
-            account: account,
-            amount: amount
-        });
-        emit CashIn(account, amount, txId);
-        if (!IERC20Mintable(_token).mint(account, amount)) {
-            revert TokenMintingFailure();
-        }
-        return CashInExecutionResult.Success;
-    }
-
-    /**
-     * @dev Executes a premint cash-in operation internally.
-     *
-     * @param account The address of the tokens recipient.
-     * @param amount The amount of tokens to be received.
-     * @param txId The off-chain transaction identifier of the operation.
-     * @return The result of the operation according to the appropriate enum.
-     */
-    function _cashInPremintCreate(
-        address account,
-        uint256 amount,
-        bytes32 txId,
-        uint256 releaseTime
-    ) internal returns (CashInExecutionResult) {
-        if (account == address(0)) {
-            revert ZeroAccount();
-        }
-        if (amount == 0) {
-            revert ZeroAmount();
-        }
-        if (txId == 0) {
-            revert ZeroTxId();
-        }
         if (releaseTime == 0) {
-            revert InappropriatePremintReleaseTime();
-        }
-        if (_cashIns[txId].status != CashInStatus.Nonexistent) {
-            revert CashInAlreadyExecuted(txId);
-        }
-        if (isBlocklisted(account)) {
-            revert BlocklistedAccount(account);
-        }
+            _cashIns[txId] = CashInOperation({
+                status: CashInStatus.Executed,
+                account: account,
+                amount: amount
+            });
+            emit CashIn(account, amount, txId);
+            if (!IERC20Mintable(_token).mint(account, amount)) {
+                revert TokenMintingFailure();
+            }
+        } else {
+            _cashIns[txId] = CashInOperation({
+                status: CashInStatus.PremintExecuted,
+                account: account,
+                amount: amount
+            });
 
-        _cashIns[txId] = CashInOperation({
-            status: CashInStatus.PremintExecuted,
-            account: account,
-            amount: amount
-        });
-
-        emit CashInPremint(account, amount, 0, txId, releaseTime);
-        IERC20Mintable(_token).premint(account, amount, releaseTime, IERC20Mintable.PremintRestriction.Update);
-
+            emit CashInPremint(account, amount, 0, txId, releaseTime);
+            IERC20Mintable(_token).premintIncrease(account, amount, releaseTime);
+        }
         return CashInExecutionResult.Success;
     }
 
     /**
-     * @dev Updates a cash-in premint operation internally depending on the release time.
+     * @dev Revokes a cash-in premint operation internally.
      *
-     * @param amount The amount of tokens to be received.
      * @param txId The off-chain transaction identifier of the operation.
      * @param releaseTime The timestamp when the tokens will be released.
-     * @return The result of the operation according to the appropriate enum.
      */
-    function _cashInPremintUpdate(
-        uint256 amount,
+    function _cashInPremintRevoke(
         bytes32 txId,
-        uint256 releaseTime
+        uint256 releaseTime,
+        CashInExecutionPolicy policy
     ) internal returns (CashInExecutionResult) {
         if (txId == 0) {
             revert ZeroTxId();
@@ -628,21 +607,114 @@ contract PixCashier is
             revert BlocklistedAccount(account);
         }
         if (_cashIns[txId].status != CashInStatus.PremintExecuted) {
-            revert InappropriateCashInStatus(txId, _cashIns[txId].status);
+            if (policy == CashInExecutionPolicy.Skip) {
+                return CashInExecutionResult.InappropriateStatus;
+            } else {
+                revert InappropriateCashInStatus(txId, _cashIns[txId].status);
+            }
         }
 
         uint256 oldAmount = cashIn_.amount;
-        cashIn_.amount = amount;
-        if (cashIn_.amount == 0) {
-            cashIn_.status = CashInStatus.Nonexistent;
-            cashIn_.account = address(0);
-        }
+        // Clearing by fields is used instead of `delete _cashIns[txId]` due to less gas consumption and bytecode size
+        cashIn_.amount = 0;
+        cashIn_.status = CashInStatus.Nonexistent;
+        cashIn_.account = address(0);
 
-        emit CashInPremint(account, amount, oldAmount, txId, releaseTime);
+        emit CashInPremint(account, 0, oldAmount, txId, releaseTime);
 
-        IERC20Mintable(_token).premint(account, amount, releaseTime, IERC20Mintable.PremintRestriction.Create);
+        IERC20Mintable(_token).premintDecrease(account, oldAmount, releaseTime);
 
         return CashInExecutionResult.Success;
+    }
+
+    /**
+     * @dev Executes a cash-in batch operation internally depending on the release time.
+     * @param accounts The array of the addresses of the tokens recipient.
+     * @param amounts The array of the token amounts to be received.
+     * @param txIds The array of the off-chain transaction identifiers of the operation.
+     * @param releaseTime Zero if the cash-ins are common otherwise the release time of the preminted tokens.
+     * @param batchId The off-chain batch identifier.
+     *
+     */
+    function _cashInBatch(
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bytes32[] memory txIds,
+        uint256 releaseTime,
+        bytes32 batchId
+    ) internal {
+        if (
+            accounts.length == 0 ||
+            accounts.length != amounts.length ||
+            accounts.length != txIds.length
+        ) {
+            revert InvalidBatchArrays();
+        }
+        if (_cashInBatches[batchId].status == CashInBatchStatus.Executed) {
+            revert CashInBatchAlreadyExecuted(batchId);
+        }
+        if (batchId == 0) {
+            revert ZeroBatchId();
+        }
+
+        CashInExecutionResult[] memory executionResults = new CashInExecutionResult[](txIds.length);
+
+        for (uint256 i = 0; i < accounts.length; i++) {
+            executionResults[i] = _cashIn(
+                accounts[i],
+                amounts[i],
+                txIds[i],
+                releaseTime,
+                CashInExecutionPolicy.Skip
+            );
+        }
+
+        if (releaseTime == 0) {
+            _cashInBatches[batchId].status = CashInBatchStatus.Executed;
+        } else {
+            _cashInBatches[batchId].status = CashInBatchStatus.PremintExecuted;
+        }
+
+        emit CashInBatch(batchId, txIds, executionResults);
+    }
+
+    /**
+     * @dev Executes a batch revocation of cash-in premint operations internally.
+     * @param txIds The array of the off-chain transaction identifiers of the operation.
+     * @param releaseTime The release time of the preminted tokens.
+     * @param batchId The off-chain batch identifier.
+     */
+    function _cashInPremintRevokeBatch(
+        bytes32[] memory txIds,
+        uint256 releaseTime,
+        bytes32 batchId
+    ) internal {
+        if (txIds.length == 0) {
+            revert InvalidBatchArrays();
+        }
+        if (releaseTime == 0) {
+            revert InappropriatePremintReleaseTime();
+        }
+        if (batchId == 0) {
+            revert ZeroBatchId();
+        }
+        if (_cashInBatches[batchId].status == CashInBatchStatus.Executed) {
+            revert CashInBatchAlreadyExecuted(batchId);
+        }
+
+        CashInExecutionResult[] memory executionResults = new CashInExecutionResult[](txIds.length);
+
+        for (uint256 i = 0; i < txIds.length; i++) {
+            executionResults[i] = _cashInPremintRevoke(
+                txIds[i],
+                releaseTime,
+                CashInExecutionPolicy.Skip
+            );
+        }
+
+        _cashInBatches[batchId].status = CashInBatchStatus.PremintExecuted;
+
+        emit CashInBatch(batchId, txIds, executionResults);
     }
 
     /**

--- a/contracts/interfaces/IERC20Mintable.sol
+++ b/contracts/interfaces/IERC20Mintable.sol
@@ -7,13 +7,6 @@ pragma solidity 0.8.16;
  * @dev The interface of a token that supports mint, premint, burn operations.
  */
 interface IERC20Mintable {
-    /// @notice An enum describing restrictions for premint operation.
-    enum PremintRestriction {
-        None,   // No restriction.
-        Create, // Creating a new premint is disallowed.
-        Update  // Updating an existing premint is disallowed.
-    }
-
     /**
      * @dev Mints tokens.
      *
@@ -24,14 +17,26 @@ interface IERC20Mintable {
     function mint(address account, uint256 amount) external returns (bool);
 
     /**
-     * @dev Premints tokens.
+     * @notice Increases the amount of an existing premint or creates a new one if it does not exist
      *
-     * @param account The address of a tokens recipient.
-     * @param amount The amount of tokens to premint.
-     * @param releaseTime The timestamp when the tokens will be released.
-     * @param restriction The restriction for the premint operation.
+     * Emits a {Premint} event
+     *
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to increase
+     * @param release The timestamp when the tokens will be released
      */
-    function premint(address account, uint256 amount, uint256 releaseTime, PremintRestriction restriction) external;
+    function premintIncrease(address account, uint256 amount, uint256 release) external;
+
+    /**
+     * @notice Decreases the amount of an existing premint or fails if it does not exist
+     *
+     * Emits a {Premint} event
+     *
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to decrease
+     * @param release The timestamp when the tokens will be released
+     */
+    function premintDecrease(address account, uint256 amount, uint256 release) external;
 
     /**
      * @dev Burns tokens.

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -24,24 +24,28 @@ interface IPixCashierTypes {
      * @dev Possible statuses of a cash-in batch operation as an enum.
      *
      * The possible values:
-     * - Nonexistent - The operation does not exist (the default value).
-     * - Executed ---- The operation was executed.
+     * - Nonexistent ----- The operation does not exist (the default value).
+     * - Executed -------- The operation was executed as common mints.
+     * - PremintExecuted - The operation was executed as premints or related to them.
      */
     enum CashInBatchStatus {
-        Nonexistent, // 0
-        Executed     // 1
+        Nonexistent,    // 0
+        Executed,       // 1
+        PremintExecuted // 2
     }
 
     /**
      * @dev Possible result statuses of a cash-in operation as an enum.
      *
      * The possible values:
-     * - Success --------- The operation was executed successfully.
-     * - AlreadyExecuted - The operation was already executed.
+     * - Success ------------- The operation was executed successfully.
+     * - AlreadyExecuted ----- The operation was already executed.
+     * - InappropriateStatus - The operation has inappropriate status and cannot be modified.
      */
     enum CashInExecutionResult {
-        Success,        // 0
-        AlreadyExecuted // 1
+        Success,            // 0
+        AlreadyExecuted,    // 1
+        InappropriateStatus // 2
     }
 
     /**
@@ -104,13 +108,13 @@ interface IPixCashier is IPixCashierTypes {
         bytes32 indexed txId     // The off-chain transaction identifier.
     );
 
-    /// @dev Emitted when a cash-in premint operation is executed.
+    /// @dev Emitted when a cash-in premint operation is executed or changed.
     event CashInPremint(
-        address indexed account, // The account that received tokens from the premint.
+        address indexed account, // The account that will receive the preminted tokens.
         uint256 newAmount,       // The new amount of preminted tokens.
         uint256 oldAmount,       // The old amount of preminted tokens.
-        bytes32 indexed txId,    // The off-chain transaction identifier.
-        uint256 releaseTime      // The timestamp when the minted tokens will become available for usage.
+        bytes32 indexed txId,    // The off-chain transaction identifier for the operation.
+        uint256 releaseTime      // The timestamp when the preminted tokens will become available for usage.
     );
 
     /// @dev Emitted when a new batch of cash-in operations is executed.
@@ -273,24 +277,6 @@ interface IPixCashier is IPixCashierTypes {
     ) external;
 
     /**
-     * @dev Updates a premint operation with the selected release time.
-     *
-     * This function is expected to be called by a limited number of accounts
-     * that are allowed to execute cash-in operations.
-     *
-     * Emits a {CashInPremint} event.
-     *
-     * @param amount The new amount of tokens to be available after release time.
-     * @param txId The off-chain transaction identifier of the operation.
-     * @param releaseTime The timestamp when the tokens will become available for usage.
-     */
-    function cashInPremintUpdate(
-        uint256 amount,
-        bytes32 txId,
-        uint256 releaseTime
-    ) external;
-
-    /**
      * @dev Executes a batch of cash-in operations as common mints.
      *
      * This function is expected to be called by a limited number of accounts
@@ -308,6 +294,48 @@ interface IPixCashier is IPixCashierTypes {
         address[] memory accounts,
         uint256[] memory amounts,
         bytes32[] memory txIds,
+        bytes32 batchId
+    ) external;
+
+    /**
+     * @dev Executes a batch of cash-in operations as premints with some predetermined release time.
+     *
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cash-in operations.
+     *
+     * Emits a {CashInBatch} event.
+     * Emits a {CashInPremint} events.
+     *
+     * @param accounts The array of the addresses of the tokens recipient.
+     * @param amounts The array of the token amounts to be received.
+     * @param txIds The array of the off-chain transaction identifiers of the operation.
+     * @param releaseTime The timestamp when the minted tokens will become available for usage.
+     * @param batchId The off-chain batch identifier.
+     */
+    function cashInPremintBatch(
+        address[] memory accounts,
+        uint256[] memory amounts,
+        bytes32[] memory txIds,
+        uint256 releaseTime,
+        bytes32 batchId
+    ) external;
+
+    /**
+     * @dev Executes a batch revocation of the existing cash-in premints that have not been released yet.
+     *
+     * This function is expected to be called by a limited number of accounts
+     * that are allowed to execute cash-in operations.
+     *
+     * Emits a {CashInBatch} event.
+     * Emits a {CashInPremint} events.
+     *
+     * @param txIds The array of the off-chain transaction identifiers of the operation.
+     * @param releaseTime The timestamp when the minted tokens will become available for usage.
+     * @param batchId The off-chain batch identifier.
+     */
+    function cashInPremintRevokeBatch(
+        bytes32[] memory txIds,
+        uint256 releaseTime,
         bytes32 batchId
     ) external;
 

--- a/contracts/mocks/tokens/ERC20TokenMock.sol
+++ b/contracts/mocks/tokens/ERC20TokenMock.sol
@@ -13,12 +13,18 @@ import { IERC20Mintable } from "../../interfaces/IERC20Mintable.sol";
 contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
     bool public mintResult;
 
-    /// @dev A mock premint event with the parameters that were passed to the `premint()` function.
-    event MockPremint(
+    /// @dev A mock premint event with the parameters that were passed to the `premintIncrease()` function.
+    event MockPremintIncreasing(
         address account,
         uint256 amount,
-        uint256 releaseTime,
-        PremintRestriction restriction
+        uint256 releaseTime
+    );
+
+    /// @dev A mock premint event with the parameters that were passed to the `premintDecrease()` function.
+    event MockPremintDecreasing(
+        address account,
+        uint256 amount,
+        uint256 releaseTime
     );
 
     /**
@@ -42,18 +48,31 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
     }
 
     /**
-     * @dev Executes the mint function ignoring the release time parameter.
-     * @param account The address of a tokens recipient.
-     * @param amount The amount of tokens to premint.
-     * @param releaseTime The timestamp when the tokens will be released.
+     * @dev Simulates the premintIncrease function by emitting the appropriate mock event.
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to increase
+     * @param release The timestamp when the tokens will be released
      */
-    function premint(
+    function premintIncrease(
         address account,
         uint256 amount,
-        uint256 releaseTime,
-        PremintRestriction restriction
+        uint256 release
     ) external {
-        emit MockPremint(account, amount, releaseTime, restriction);
+        emit MockPremintIncreasing(account, amount, release);
+    }
+
+    /**
+     * @dev Simulates the premintDecrease function by emitting the appropriate mock event.
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to decrease
+     * @param release The timestamp when the tokens will be released
+     */
+    function premintDecrease(
+        address account,
+        uint256 amount,
+        uint256 release
+    ) external {
+        emit MockPremintDecreasing(account, amount, release);
     }
 
     /**

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -826,6 +826,14 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(
         pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       );
+      const releaseTimestamp: number = 123456;
+      await proveTx(pixCashier.connect(cashier).cashInPremintBatch(
+        userAddresses,
+        TOKEN_AMOUNTS,
+        TRANSACTIONS_ARRAY,
+        releaseTimestamp,
+        BATCH_ID_STUB2
+      ));
       await expect(
         pixCashier.connect(cashier).cashInBatch(
           userAddresses,
@@ -837,6 +845,17 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier,
         REVERT_ERROR_IF_CASH_IN_BATCH_ALREADY_EXECUTED
       ).withArgs(BATCH_ID_STUB1);
+      await expect(
+        pixCashier.connect(cashier).cashInBatch(
+          userAddresses,
+          TOKEN_AMOUNTS,
+          TRANSACTIONS_ARRAY,
+          BATCH_ID_STUB2
+        )
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_CASH_IN_BATCH_ALREADY_EXECUTED
+      ).withArgs(BATCH_ID_STUB2);
     });
   });
 
@@ -1089,6 +1108,13 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(
         pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       );
+      await proveTx(pixCashier.connect(cashier).cashInPremintBatch(
+        userAddresses,
+        TOKEN_AMOUNTS,
+        TRANSACTIONS_ARRAY,
+        releaseTimestamp,
+        BATCH_ID_STUB2
+      ));
       await expect(
         pixCashier.connect(cashier).cashInPremintBatch(
           userAddresses,
@@ -1101,6 +1127,18 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier,
         REVERT_ERROR_IF_CASH_IN_BATCH_ALREADY_EXECUTED
       ).withArgs(BATCH_ID_STUB1);
+      await expect(
+        pixCashier.connect(cashier).cashInPremintBatch(
+          userAddresses,
+          TOKEN_AMOUNTS,
+          TRANSACTIONS_ARRAY,
+          releaseTimestamp,
+          BATCH_ID_STUB2
+        )
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_CASH_IN_BATCH_ALREADY_EXECUTED
+      ).withArgs(BATCH_ID_STUB2);
     });
   });
 
@@ -1291,6 +1329,13 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(
         pixCashier.connect(cashier).cashInBatch(userAddresses, TOKEN_AMOUNTS, TRANSACTIONS_ARRAY, BATCH_ID_STUB1)
       );
+      await proveTx(pixCashier.connect(cashier).cashInPremintBatch(
+        userAddresses,
+        TOKEN_AMOUNTS,
+        TRANSACTIONS_ARRAY,
+        releaseTimestamp,
+        BATCH_ID_STUB2
+      ));
       await expect(
         pixCashier.connect(cashier).cashInPremintRevokeBatch(
           TRANSACTIONS_ARRAY,
@@ -1301,6 +1346,16 @@ describe("Contract 'PixCashier'", async () => {
         pixCashier,
         REVERT_ERROR_IF_CASH_IN_BATCH_ALREADY_EXECUTED
       ).withArgs(BATCH_ID_STUB1);
+      await expect(
+        pixCashier.connect(cashier).cashInPremintRevokeBatch(
+          TRANSACTIONS_ARRAY,
+          releaseTimestamp,
+          BATCH_ID_STUB2
+        )
+      ).to.be.revertedWithCustomError(
+        pixCashier,
+        REVERT_ERROR_IF_CASH_IN_BATCH_ALREADY_EXECUTED
+      ).withArgs(BATCH_ID_STUB2);
     });
   });
 


### PR DESCRIPTION
## Main Changes
1. The `cashInPremintUpdate()` function has been removed.
2. The `cashInPremint()` function behavior has been changed. It now allows not only create new premints for an account, but also change previously created ones by increasing the amount.
3. The `cashInPremintRevoke()` function behavior has been changed. It now only decreases the amount of an existing premint for an account instead of zeroing it completely. The amount of decreasing is taken from the previously made cash-in premint operation according the provided `txId`.
4. The new `cashInPremintBatch()` function has been added. It is similar to the existing `cashInBatch()` function and allows to execute multiple cash-in premint operation in a batch.
5. The new `cashInPremintRevokeBatch()` function has been added. It allows to revoke multiple previously made cash-in premint operation in a batch.

## Functions Declarations

<details>
  <summary>Functions declaration code</summary>

  ```solidity
  /**
     * @dev Executes a cash-in operation as a premint with some predetermined release time.
     * @param account The address of the tokens recipient.
     * @param amount The amount of tokens to be received.
     * @param txId The off-chain transaction identifier of the operation.
     * @param releaseTime The timestamp when the minted tokens will become available for usage.
     */
    function cashInPremint(
        address account,
        uint256 amount,
        bytes32 txId,
        uint256 releaseTime
    ) external whenNotPaused onlyRole(CASHIER_ROLE) {....}
  
    /**
     * @dev Revokes the existing premint that has not yet been released.
     * @param txId The off-chain transaction identifier of the operation.
     * @param releaseTime The timestamp of the premint that will be revoked.
     */
    function cashInPremintRevoke(
        bytes32 txId,
        uint256 releaseTime
    ) external whenNotPaused onlyRole(CASHIER_ROLE) {....}
  
    /**
     * @dev Executes a batch of cash-in operations as premints with some predetermined release time.
     * @param accounts The array of the addresses of the tokens recipient.
     * @param amounts The array of the token amounts to be received.
     * @param txIds The array of the off-chain transaction identifiers of the operation.
     * @param releaseTime The timestamp when the minted tokens will become available for usage.
     * @param batchId The off-chain batch identifier.
     */
    function cashInPremintBatch(
        address[] memory accounts,
        uint256[] memory amounts,
        bytes32[] memory txIds,
        uint256 releaseTime,
        bytes32 batchId
    ) external whenNotPaused onlyRole(CASHIER_ROLE) {....}
  
    /**
     * @dev Executes a batch revocation of the existing cash-in premints that have not been released yet.
     * @param txIds The array of the off-chain transaction identifiers of the operation.
     * @param releaseTime The timestamp when the minted tokens will become available for usage.
     * @param batchId The off-chain batch identifier.
     */
    function cashInPremintRevokeBatch(
        bytes32[] memory txIds,
        uint256 releaseTime,
        bytes32 batchId
    ) external whenNotPaused onlyRole(CASHIER_ROLE) {....}
  ```
</details>

## Premint Functions Description
1. All the premint functions can be called only by an account with the `Cashier` role.
2. If the `cashInPremint()` function succeeds:
    * A new `CashInOperation` structure for the provided `txId` value is made.
    * The structure's field `status = CashInStatus.PremintExecuted`.
    * The appropriate function of the underlying token contract is called to creates a new premint or increase the amount of the existing one. The corresponding premint is searched by the provided `account` and `releaseTime` values.
    * A corresponding event is emitted.
3. If the `cashInPremintRevoke()` function succeeds:
    * The existing `CashInOperation` structure for the provided `txId` value is cleared.
    * The structure's field `status = CashInStatus.Nonexistent`.
    * The appropriate function of the underlying token contract is called to decrease the amount of the existing premint. The corresponding premint is searched by the provided `releaseTime` value and the `CashInOperation.account` field (before clearing).
    * A corresponding event is emitted.
4. Both `cashInPremint()` and `cashInPremintRevoke()` functions emit the `CashInPremint` event if succeed:
    <details>
        <summary>Event code</summary>
        
      ```solidity
      /// @dev Emitted when a cash-in premint operation is executed or changed.
      event CashInPremint(
          address indexed account, // The account that will receive the preminted tokens.
          uint256 newAmount,       // The new amount of preminted tokens.
          uint256 oldAmount,       // The old amount of preminted tokens.
          bytes32 indexed txId,    // The off-chain transaction identifier for the operation.
          uint256 releaseTime      // The timestamp when the preminted tokens will become available for usage.
      );
      ```
    </details>
5. The `cashInPremintBatch()` function executes like the `cashInPremint()` for each provided set of values `accounts[i]`, amounts[i]`, `txIds[i]`, `releaseTime`. If a cash-in operation for some of the provided `txId` values is already executed, then the operation will be skipped without reverting the transaction. The `CashInPremint` event is emitted for each successfully processed cash-in operation.
6. The `cashInPremintRevokeBatch()` function executes like the `cashInPremintRevoke()` for each provided set of values `txIds[i]` and `releaseTime`. If a cash-in operation for some of the provided `txId` values has inappropriate status and cannot be revoked, then the operation will be skipped without reverting the transaction. The `CashInPremint` event is emitted for each successfully revoked cash-in operation.
7. Both `cashInPremintBatch()` and `cashInPremintRevokeBatch()` functions emit the aggregated `CashInBatch` event if succeed:
    <details>
        <summary>Event code</summary>
        
      ```solidity
      /// @dev Emitted when a new batch of cash-in operations is executed.
      event CashInBatch(
          bytes32 indexed batchId,                 // The off-chain batch identifier.
          bytes32[] txIds,                         // The array of off-chain identifiers for each operation in the batch.
          CashInExecutionResult[] executionResults // The array of execution results for each operation in the batch.
      );
      
      /**
       * @dev Possible result statuses of a cash-in operation as an enum.
       *
       * The possible values:
       * - Success ------------- The operation was executed successfully.
       * - AlreadyExecuted ----- The operation was already executed.
       * - InappropriateStatus - The operation has inappropriate status and cannot be modified.
       */
      enum CashInExecutionResult {
          Success,            // 0
          AlreadyExecuted,    // 1
          InappropriateStatus // 2
      }
      ```
    </details>
 
 7. The revert conditions for the `cashInPremint()` function:
    * a. If the contract is paused or the caller does not have the `Cashier` role.
    * b. If the passed `releaseTime` value is zero -- error `InappropriatePremintReleaseTime`.
    * c. If the passed `account` value is zero address -- error `ZeroAccount`.
    * d. If the passed `amount` value is zero -- error `ZeroAmount`.
    * e. If the passed `txId` value is zero -- error `ZeroTxId`.
    * f. If the recipient of the cash-in is blocklisted on the contract.
    * g. If the cash-in operation with provided `txId` is already executed.
    * h. If the premint function of the underlying token contract is reverted.
 8. The revert conditions for the `cashInPremintRevoke()` function:
    * a. The revert conditions for the `cashInPremint()` function except `c`, `d`, `g`.
    * b. If the cash-in operation with provided `txId` does not have the `CashInStatus.PremintExecuted` status.
 9. The revert conditions for the `cashInPremintBatch()` function:
    * a. The revert conditions for the `cashInPremint()` function except `g`.
    * b. If one of the input arrays is empty or its length differs from other arrays.
    * c. If the batch operation with provided `batchId` is already executed -- error `CashInBatchAlreadyExecuted`.
10.  The revert conditions for the `cashInPremintRevokeBatch()` function:
    * a. The revert conditions for the `cashInPremintRevoke()` function except `b`.
    * b. If the `txIds` input array is empty.
    * c. If the batch operation with provided `batchId` is already executed -- error `CashInBatchAlreadyExecuted`.

## Functions Usage Examples

| # | Functions with arguments in the call order | Consequences |
|---:|:---|:---|
| 1 | `cashInPremint()`, `account=0x1`, `amount=10`, `txId=0xA`, `releaseTime=101` | A new cash-in operation structure `C1` with the provided paremeters is created. A new premint `P1` with provided parameters is created. `C1.status=CashInStatus.PremintExecuted`, `C1.account=0x1`, `C1.amount=10`, `P1.amount=10`, `P1.release=101` | 
| 2 | `cashInPremint()`, `account=0x1`, `amount=5`, `txId=0xB`, `releaseTime=101` | A new cash-in operation structure `C2` with the provided paremeters is created.  The existing premint `P1` is changed. `C2.status=CashInStatus.PremintExecuted`, `C2.account=0x1`, `C2.amount=5`, `P1.amount=15`, `P1.release=101`  |
| 3 | `cashInPremint()`, `account=0x1`, `amount=20`, `txId=0xC`, `releaseTime=102` | A new cash-in operation structure `C3` with the provided paremeters is created.  A new premint `P2` with provided parameters is created. `C3.status=CashInStatus.PremintExecuted`, `C3.account=0x1`, `C3.amount=20`, `P2.amount=20`, `P2.release=102`  |
| 4 | `cashInPremintRevoke()`, `txId=0xB`, `releaseTime=101` | The existing cash-in operation structure `C2` is cleared.  The existing premint `P1` is changed. `C2.status=CashInStatus.Nonexistent`, `C2.account=0`, `C2.amount=0`, `P1.amount=10`, `P1.release=101` |
| 5 | `cashInPremint()`, `account=0x2`, `amount=30`, `txId=0xA`, `release=102` | Revert because the cash-in operation with the provided `txId` is already executed: `C1` that is created at step 1 |
| 6 | `cashInPremintRevoke()`, `txId=0xB`, `release=101` | Revert because the cash-in operation with the provided `txId` does not exist (`C2` that was cleared at step 4) |

## Test coverage
New functionality was fully covered with tests