### PR TITLE
Premints rescheduling

### DIFF
--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -406,21 +406,20 @@ contract PixCashier is
     }
 
     /**
-     * @dev See {IPixCashier-reschedulePremints}.
+     * @dev See {IPixCashier-reschedulePremintRelease}.
      *
      * Requirements
      *
      * - The contract must not be paused.
      * - The caller must have the {CASHIER_ROLE} role.
      * - The original and target release timestamps must meet the requirements of the appropriate function of the
-     *   underlying token contract
+     *   underlying token contract.
      */
-    function cashInReschedulePremints(
+    function reschedulePremintRelease(
         uint256 originalRelease,
         uint256 targetRelease
     ) external whenNotPaused onlyRole(CASHIER_ROLE) {
-        IERC20Mintable(_token).reschedulePremints(originalRelease, targetRelease);
-        emit CashInPremintsRescheduled(originalRelease, targetRelease);
+        IERC20Mintable(_token).reschedulePremintRelease(originalRelease, targetRelease);
     }
 
     /**

--- a/contracts/PixCashier.sol
+++ b/contracts/PixCashier.sol
@@ -406,6 +406,24 @@ contract PixCashier is
     }
 
     /**
+     * @dev See {IPixCashier-reschedulePremints}.
+     *
+     * Requirements
+     *
+     * - The contract must not be paused.
+     * - The caller must have the {CASHIER_ROLE} role.
+     * - The original and target release timestamps must meet the requirements of the appropriate function of the
+     *   underlying token contract
+     */
+    function cashInReschedulePremints(
+        uint256 originalRelease,
+        uint256 targetRelease
+    ) external whenNotPaused onlyRole(CASHIER_ROLE) {
+        IERC20Mintable(_token).reschedulePremints(originalRelease, targetRelease);
+        emit CashInPremintsRescheduled(originalRelease, targetRelease);
+    }
+
+    /**
      * @dev See {IPixCashier-requestCashOutFrom}.
      *
      * Requirements:

--- a/contracts/interfaces/IERC20Mintable.sol
+++ b/contracts/interfaces/IERC20Mintable.sol
@@ -39,6 +39,16 @@ interface IERC20Mintable {
     function premintDecrease(address account, uint256 amount, uint256 release) external;
 
     /**
+     * @notice Reschedules one release timestamp for all existing or future premints with another release timestamp
+     *
+     * Emits a {PremintsRescheduled} event
+     *
+     * @param originalRelease The premint release timestamp to be rescheduled
+     * @param targetRelease The target premint release timestamp to be set during the rescheduling
+     */
+    function reschedulePremints(uint256 originalRelease, uint256 targetRelease) external;
+
+    /**
      * @dev Burns tokens.
      *
      * @param amount The amount of tokens to burn.

--- a/contracts/interfaces/IERC20Mintable.sol
+++ b/contracts/interfaces/IERC20Mintable.sol
@@ -17,36 +17,30 @@ interface IERC20Mintable {
     function mint(address account, uint256 amount) external returns (bool);
 
     /**
-     * @notice Increases the amount of an existing premint or creates a new one if it does not exist
+     * @dev Increases the amount of an existing premint or creates a new one if it does not exist.
      *
-     * Emits a {Premint} event
-     *
-     * @param account The address of a tokens recipient
-     * @param amount The amount of tokens to increase
-     * @param release The timestamp when the tokens will be released
+     * @param account The address of a tokens recipient.
+     * @param amount The amount of tokens to increase.
+     * @param release The timestamp when the tokens will be released.
      */
     function premintIncrease(address account, uint256 amount, uint256 release) external;
 
     /**
-     * @notice Decreases the amount of an existing premint or fails if it does not exist
+     * @dev Decreases the amount of an existing premint or fails if it does not exist.
      *
-     * Emits a {Premint} event
-     *
-     * @param account The address of a tokens recipient
-     * @param amount The amount of tokens to decrease
-     * @param release The timestamp when the tokens will be released
+     * @param account The address of a tokens recipient.
+     * @param amount The amount of tokens to decrease.
+     * @param release The timestamp when the tokens will be released.
      */
     function premintDecrease(address account, uint256 amount, uint256 release) external;
 
     /**
-     * @notice Reschedules one release timestamp for all existing or future premints with another release timestamp
+     * @dev Reschedules original premint release to a new target release.
      *
-     * Emits a {PremintsRescheduled} event
-     *
-     * @param originalRelease The premint release timestamp to be rescheduled
-     * @param targetRelease The target premint release timestamp to be set during the rescheduling
+     * @param originalRelease The timestamp of the original premint release to be rescheduled.
+     * @param targetRelease The new timestamp of the premint release to set during the rescheduling.
      */
-    function reschedulePremints(uint256 originalRelease, uint256 targetRelease) external;
+    function reschedulePremintRelease(uint256 originalRelease, uint256 targetRelease) external;
 
     /**
      * @dev Burns tokens.

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -117,12 +117,6 @@ interface IPixCashier is IPixCashierTypes {
         uint256 releaseTime      // The timestamp when the preminted tokens will become available for usage.
     );
 
-    /// @dev Emitted when one release for all existing or future premints has been rescheduled to another release
-    event CashInPremintsRescheduled(
-        uint256 indexed originalRelease,
-        uint256 indexed targetRelease
-    );
-
     /// @dev Emitted when a new batch of cash-in operations is executed.
     event CashInBatch(
         bytes32 indexed batchId,                 // The off-chain batch identifier.
@@ -346,14 +340,12 @@ interface IPixCashier is IPixCashierTypes {
     ) external;
 
     /**
-     * @notice Reschedules one release for all existing or future cash-in premints with another release
+     * @dev Reschedules original cash-in premint release to a new target release.
      *
-     * Emits a {CashInPremintsRescheduled} event
-     *
-     * @param originalRelease The premint release timestamp to be rescheduled
-     * @param targetRelease The target premint release timestamp to be set during the rescheduling
+     * @param originalRelease The timestamp of the original premint release to be rescheduled.
+     * @param targetRelease The new timestamp of the premint release to set during the rescheduling.
      */
-    function cashInReschedulePremints(uint256 originalRelease, uint256 targetRelease) external;
+    function reschedulePremintRelease(uint256 originalRelease, uint256 targetRelease) external;
 
     /**
      * @dev Initiates a cash-out operation from some other account.

--- a/contracts/interfaces/IPixCashier.sol
+++ b/contracts/interfaces/IPixCashier.sol
@@ -117,6 +117,12 @@ interface IPixCashier is IPixCashierTypes {
         uint256 releaseTime      // The timestamp when the preminted tokens will become available for usage.
     );
 
+    /// @dev Emitted when one release for all existing or future premints has been rescheduled to another release
+    event CashInPremintsRescheduled(
+        uint256 indexed originalRelease,
+        uint256 indexed targetRelease
+    );
+
     /// @dev Emitted when a new batch of cash-in operations is executed.
     event CashInBatch(
         bytes32 indexed batchId,                 // The off-chain batch identifier.
@@ -338,6 +344,16 @@ interface IPixCashier is IPixCashierTypes {
         uint256 releaseTime,
         bytes32 batchId
     ) external;
+
+    /**
+     * @notice Reschedules one release for all existing or future cash-in premints with another release
+     *
+     * Emits a {CashInPremintsRescheduled} event
+     *
+     * @param originalRelease The premint release timestamp to be rescheduled
+     * @param targetRelease The target premint release timestamp to be set during the rescheduling
+     */
+    function cashInReschedulePremints(uint256 originalRelease, uint256 targetRelease) external;
 
     /**
      * @dev Initiates a cash-out operation from some other account.

--- a/contracts/mocks/tokens/ERC20TokenMock.sol
+++ b/contracts/mocks/tokens/ERC20TokenMock.sol
@@ -27,8 +27,8 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
         uint256 releaseTime
     );
 
-    /// @dev A mock premint event with the parameters that were passed to the `reschedulePremints()` function.
-    event MockPremintsRescheduling(
+    /// @dev A mock premint event with the parameters that were passed to the `reschedulePremintRelease()` function.
+    event MockPremintReleaseRescheduling(
         uint256 originalRelease,
         uint256 targetRelease
     );
@@ -55,9 +55,9 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
 
     /**
      * @dev Simulates the premintIncrease function by emitting the appropriate mock event.
-     * @param account The address of a tokens recipient
-     * @param amount The amount of tokens to increase
-     * @param release The timestamp when the tokens will be released
+     * @param account The address of a tokens recipient.
+     * @param amount The amount of tokens to increase.
+     * @param release The timestamp when the tokens will be released.
      */
     function premintIncrease(
         address account,
@@ -69,9 +69,9 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
 
     /**
      * @dev Simulates the premintDecrease function by emitting the appropriate mock event.
-     * @param account The address of a tokens recipient
-     * @param amount The amount of tokens to decrease
-     * @param release The timestamp when the tokens will be released
+     * @param account The address of a tokens recipient.
+     * @param amount The amount of tokens to decrease.
+     * @param release The timestamp when the tokens will be released.
      */
     function premintDecrease(
         address account,
@@ -82,15 +82,12 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
     }
 
     /**
-     * @notice Simulates the reschedulePremints function by emitting the appropriate mock event.
-     *
-     * Emits a {PremintsRescheduled} event
-     *
-     * @param originalRelease The premint release timestamp to be rescheduled
-     * @param targetRelease The target premint release timestamp to be set during the rescheduling
+     * @dev Simulates the reschedulePremintRelease function by emitting the appropriate mock event.
+     * @param originalRelease The premint release timestamp to be rescheduled.
+     * @param targetRelease The target premint release timestamp to be set during the rescheduling.
      */
-    function reschedulePremints(uint256 originalRelease, uint256 targetRelease) external {
-        emit MockPremintsRescheduling(originalRelease, targetRelease);
+    function reschedulePremintRelease(uint256 originalRelease, uint256 targetRelease) external {
+        emit MockPremintReleaseRescheduling(originalRelease, targetRelease);
     }
 
     /**
@@ -101,7 +98,11 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
         _burn(msg.sender, amount);
     }
 
-    function setMintResult(bool _newMintResult) external {
-        mintResult = _newMintResult;
+    /**
+     * @dev Sets the mint result to the new value.
+     * @param newMintResult The new value to set for the mint result.
+     */
+    function setMintResult(bool newMintResult) external {
+        mintResult = newMintResult;
     }
 }

--- a/contracts/mocks/tokens/ERC20TokenMock.sol
+++ b/contracts/mocks/tokens/ERC20TokenMock.sol
@@ -27,6 +27,12 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
         uint256 releaseTime
     );
 
+    /// @dev A mock premint event with the parameters that were passed to the `reschedulePremints()` function.
+    event MockPremintsRescheduling(
+        uint256 originalRelease,
+        uint256 targetRelease
+    );
+
     /**
      * @dev The initialize function of the upgradable contract.
      * @param name_ The name of the token to set for this ERC20-comparable contract.
@@ -73,6 +79,18 @@ contract ERC20TokenMock is ERC20Upgradeable, IERC20Mintable {
         uint256 release
     ) external {
         emit MockPremintDecreasing(account, amount, release);
+    }
+
+    /**
+     * @notice Simulates the reschedulePremints function by emitting the appropriate mock event.
+     *
+     * Emits a {PremintsRescheduled} event
+     *
+     * @param originalRelease The premint release timestamp to be rescheduled
+     * @param targetRelease The target premint release timestamp to be set during the rescheduling
+     */
+    function reschedulePremints(uint256 originalRelease, uint256 targetRelease) external {
+        emit MockPremintsRescheduling(originalRelease, targetRelease);
     }
 
     /**

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -1359,6 +1359,55 @@ describe("Contract 'PixCashier'", async () => {
     });
   });
 
+  describe("Function 'cashInReschedulePremints()'", async () => {
+    const originalReleaseTimestamp = 123;
+    const targetReleaseTimestamp = 321;
+
+    beforeEach(async () => {
+      await proveTx(pixCashier.grantRole(cashierRole, cashier.address));
+    });
+
+    it("Executes as expected", async () => {
+      const tx: TransactionResponse = await pixCashier.connect(cashier).cashInReschedulePremints(
+        originalReleaseTimestamp,
+        targetReleaseTimestamp
+      );
+
+      await expect(tx)
+        .to.emit(tokenMock, "MockPremintsRescheduling")
+        .withArgs(
+          originalReleaseTimestamp,
+          targetReleaseTimestamp
+        );
+      await expect(tx)
+        .to.emit(pixCashier, "CashInPremintsRescheduled")
+        .withArgs(
+          originalReleaseTimestamp,
+          targetReleaseTimestamp
+        );
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
+      await proveTx(pixCashier.pause());
+      await expect(
+        pixCashier.connect(cashier).cashInReschedulePremints(
+          originalReleaseTimestamp,
+          targetReleaseTimestamp
+        )
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_PAUSED);
+    });
+
+    it("Is reverted if the caller does not have the cashier role", async () => {
+      await expect(
+        pixCashier.connect(deployer).cashInReschedulePremints(
+          originalReleaseTimestamp,
+          targetReleaseTimestamp
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, cashierRole));
+    });
+  });
+
   describe("Function 'requestCashOutFrom()'", async () => {
     let cashOut: TestCashOut;
 

--- a/test/PixCashier.test.ts
+++ b/test/PixCashier.test.ts
@@ -1359,7 +1359,7 @@ describe("Contract 'PixCashier'", async () => {
     });
   });
 
-  describe("Function 'cashInReschedulePremints()'", async () => {
+  describe("Function 'reschedulePremintRelease()'", async () => {
     const originalReleaseTimestamp = 123;
     const targetReleaseTimestamp = 321;
 
@@ -1368,19 +1368,13 @@ describe("Contract 'PixCashier'", async () => {
     });
 
     it("Executes as expected", async () => {
-      const tx: TransactionResponse = await pixCashier.connect(cashier).cashInReschedulePremints(
+      const tx: TransactionResponse = await pixCashier.connect(cashier).reschedulePremintRelease(
         originalReleaseTimestamp,
         targetReleaseTimestamp
       );
 
       await expect(tx)
-        .to.emit(tokenMock, "MockPremintsRescheduling")
-        .withArgs(
-          originalReleaseTimestamp,
-          targetReleaseTimestamp
-        );
-      await expect(tx)
-        .to.emit(pixCashier, "CashInPremintsRescheduled")
+        .to.emit(tokenMock, "MockPremintReleaseRescheduling")
         .withArgs(
           originalReleaseTimestamp,
           targetReleaseTimestamp
@@ -1391,7 +1385,7 @@ describe("Contract 'PixCashier'", async () => {
       await proveTx(pixCashier.grantRole(pauserRole, deployer.address));
       await proveTx(pixCashier.pause());
       await expect(
-        pixCashier.connect(cashier).cashInReschedulePremints(
+        pixCashier.connect(cashier).reschedulePremintRelease(
           originalReleaseTimestamp,
           targetReleaseTimestamp
         )
@@ -1400,7 +1394,7 @@ describe("Contract 'PixCashier'", async () => {
 
     it("Is reverted if the caller does not have the cashier role", async () => {
       await expect(
-        pixCashier.connect(deployer).cashInReschedulePremints(
+        pixCashier.connect(deployer).reschedulePremintRelease(
           originalReleaseTimestamp,
           targetReleaseTimestamp
         )


### PR DESCRIPTION
## Main Changes
1. The ability to reschedule cash-in premints from one release timestamp to another has been implemented using the appropriate function in the underlying token contract. See [this PR](https://github.com/cloudwalk/brlc-token/pull/73) for details.
2. The new `cashInReschedulePremints()` function has been added to configure the reschedulings.
3. The new event `CashInPremintsRescheduled` has been added. It is emitted when a new rescheduling is configured.

## Declarations of the New Functions and Event
<details>
  <summary>Declarations code</summary>

  ```solidity
    /**
     * @notice Reschedules one release for all existing or future cash-in premints with another release
     *
     * Emits a {CashInPremintsRescheduled} event
     *
     * @param originalRelease The premint release timestamp to be rescheduled
     * @param targetRelease The target premint release timestamp to be set during the rescheduling
     */
    function cashInReschedulePremints(
        uint256 originalRelease,
        uint256 targetRelease
    ) external whenNotPaused onlyRole(CASHIER_ROLE) {....}

    /// @dev Emitted when one release for all existing or future premints has been rescheduled to another release
    event CashInPremintsRescheduled(
        uint256 indexed originalRelease,
        uint256 indexed targetRelease
    );
  ```

</details>

## Details of Function `cashInReschedulePremints()`
1. The function can be called only by an account with the `Cashier` role when the contract is not paused.
2. The functions emits the `CashInPremintsRescheduled` event if succeed.
3. The revert conditions of the function are the same as for the `reschedulePremints()` function of the token contract.

## Test coverage
![image](https://github.com/cloudwalk/brlc-pix-cashier/assets/97302011/9a1eb510-dbe2-4e2e-a4d5-e30543f26146)
