### PR TITLE
Introduce shard admin feature

### DIFF
--- a/contracts/PixCashierRoot.sol
+++ b/contracts/PixCashierRoot.sol
@@ -360,6 +360,25 @@ contract PixCashierRoot is
         }
     }
 
+    /**
+     * @inheritdoc IPixCashierRoot
+     *
+     * @dev Requirements:
+     *
+     * - The caller must have the {OWNER_ROLE} role.
+     */
+    function configureShardAdmin(address account, bool status) external onlyRole(OWNER_ROLE) {
+        if (account == address(0)) {
+            revert ZeroAccount();
+        }
+
+        for (uint256 i; i < _shards.length; i++) {
+            _shards[i].setAdmin(account, status);
+        }
+
+        emit ShardAdminConfigured(account, status);
+    }
+
     // ------------------ View functions -------------------------- //
 
     /**

--- a/contracts/PixCashierShardStorage.sol
+++ b/contracts/PixCashierShardStorage.sol
@@ -16,6 +16,14 @@ abstract contract PixCashierShardStorageV1 is IPixCashierTypes {
 }
 
 /**
+ * @title PixCashierShard storage version 2
+ */
+abstract contract PixCashierShardStorageV2 is IPixCashierTypes {
+    /// @dev The mapping of an account to its admin status (True if admin, False otherwise).
+    mapping(address => bool) internal _admins;
+}
+
+/**
  * @title PixCashierShard storage
  * @dev Contains storage variables of the {PixCashierShard} contract.
  *
@@ -25,10 +33,10 @@ abstract contract PixCashierShardStorageV1 is IPixCashierTypes {
  * e.g. PixCashierShardStorage<versionNumber>, so finally it would look like
  * "contract PixCashierShardStorage is PixCashierShardStorageV1, PixCashierShardStorageV2".
  */
-abstract contract PixCashierShardStorage is PixCashierShardStorageV1 {
+abstract contract PixCashierShardStorage is PixCashierShardStorageV1, PixCashierShardStorageV2 {
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      */
-    uint256[48] private __gap;
+    uint256[47] private __gap;
 }

--- a/contracts/interfaces/IPixCashierRoot.sol
+++ b/contracts/interfaces/IPixCashierRoot.sol
@@ -55,6 +55,9 @@ interface IPixCashierRoot is IPixCashierTypes {
     /// @dev Emitted when a new shard is added to the contract.
     event ShardAdded(address shard);
 
+    /// @dev Emitted when a shard admin status of an account is configured.
+    event ShardAdminConfigured(address account, bool status);
+
     // ------------------ Functions ------------------------------- //
 
     /**
@@ -161,6 +164,13 @@ interface IPixCashierRoot is IPixCashierTypes {
      * @param shards The array of shard addresses to add.
      */
     function addShards(address[] memory shards) external;
+
+    /**
+     * @dev Configures the shard admin status of an account.
+     * @param account The address of the account to configure.
+     * @param status The new admin status of the account.
+     */
+    function configureShardAdmin(address account, bool status) external;
 
     // ------------------ View functions -------------------------- //
 

--- a/contracts/interfaces/IPixCashierShard.sol
+++ b/contracts/interfaces/IPixCashierShard.sol
@@ -24,6 +24,13 @@ interface IPixCashierShard is IPixCashierTypes {
     }
 
     /**
+     * @dev Sets the admin status of an account.
+     * @param account The address of the account to configure.
+     * @param status The admin status of the account.
+     */
+    function setAdmin(address account, bool status) external;
+
+    /**
      * @dev Registers a cash-in operation.
      * @param account The address of the account.
      * @param amount The amount of the cash-in operation.
@@ -95,6 +102,13 @@ interface IPixCashierShard is IPixCashierTypes {
      * @return operations The data of the cash-out operations in the form of a structure.
      */
     function getCashOuts(bytes32[] memory txIds) external view returns (CashOutOperation[] memory operations);
+
+    /**
+     * @dev Checks if an account is an admin.
+     * @param account The address of the account to check.
+     * @return isAdmin The admin status of the account.
+     */
+    function isAdmin(address account) external view returns (bool);
 
     /**
      * @dev Upgrades the implementation of the contract.


### PR DESCRIPTION
## Main changes

With the current changes, it will be possible to use the same set of `PixCashierShard` contracts with multiple `PixCashierRoot` contracts on top of it. To achieve this, the shard admin functionality has been implemented. Now any `PixCashierRoot` contract configured as an administrator on the `PixCashierShard` contract will be able to interact with that contract, performing cash-in and cash-out operations.

## Functions and Events declaration

PixCashierRoot contract:
```Solidity
    /// @dev Emitted when a shard admin status of an account is configured.
    event ShardAdminConfigured(address account, bool status);

    /**
     * @dev Configures the shard admin status of an account.
     * @param account The address of the account to configure.
     * @param status The new admin status of the account.
     */
    function configureShardAdmin(address account, bool status) external;
```

PixCashierShard contract:
```Solidity
    /// @dev Throws if the caller is not the owner or admin.
    error Unauthorized();

    /**
     * @dev Sets the admin status of an account.
     * @param account The address of the account to configure.
     * @param status The admin status of the account.
     */
    function setAdmin(address account, bool status) external;

    /**
     * @dev Checks if an account is an admin.
     * @param account The address of the account to check.
     * @return isAdmin The admin status of the account.
     */
    function isAdmin(address account) external view returns (bool);
```

## Test coverage

New functionality was fully covered by tests.